### PR TITLE
Disable unused reference sliders in Cassini example

### DIFF
--- a/Examples/Cassini/ContentView+Model.swift
+++ b/Examples/Cassini/ContentView+Model.swift
@@ -25,8 +25,24 @@ extension ContentView {
     case naturalEarth
     case orthographic
     case azimuthal
-    
+
     var id: String { rawValue }
+
+    /// Whether the projection's output depends on the reference latitude.
+    var usesReferenceLatitude: Bool {
+      switch self {
+      case .orthographic, .azimuthal: return true
+      case .equirectangular, .cassini, .mercator, .gallPeters, .equalEarth, .naturalEarth: return false
+      }
+    }
+
+    /// Whether the projection's output depends on the reference longitude.
+    var usesReferenceLongitude: Bool {
+      switch self {
+      case .cassini: return false
+      case .equirectangular, .mercator, .gallPeters, .equalEarth, .naturalEarth, .orthographic, .azimuthal: return true
+      }
+    }
   }
   
   struct Layer: Identifiable {

--- a/Examples/Cassini/ContentView.swift
+++ b/Examples/Cassini/ContentView.swift
@@ -203,25 +203,27 @@ struct OptionsView: View {
               .frame(width: 100, alignment: .trailing)
           }
           .frame(minWidth: 200)
-          
+
           TextField(value: $model.refLat, format: .number.precision(.fractionLength(1))) {
             EmptyView()
           }
           .frame(maxWidth: 55)
         }
-        
+        .disabled(!model.projectionType.usesReferenceLatitude)
+
         HStack {
           Slider(value: $model.refLng, in: -180...180) {
             Text("Longitude")
               .frame(width: 100, alignment: .trailing)
           }
           .frame(minWidth: 200)
-          
+
           TextField(value: $model.refLng, format: .number.precision(.fractionLength(1))) {
             EmptyView()
           }
           .frame(maxWidth: 55)
         }
+        .disabled(!model.projectionType.usesReferenceLongitude)
       }
       
       GroupBox("Edge Insets") {


### PR DESCRIPTION
Each projection ignores the reference latitude and/or longitude in different ways. Grey out the slider+text-field row whose value the selected projection would discard, so the controls reflect what they actually affect.