### PR TITLE
Close bezier mapBounds path so the outline joins back

### DIFF
--- a/Sources/GeoDrawer/GeoDrawer+CoreGraphics.swift
+++ b/Sources/GeoDrawer/GeoDrawer+CoreGraphics.swift
@@ -173,6 +173,9 @@ extension GeoDrawer {
       for point in points[1...] {
         mutable.addLine(to: point.cgPoint)
       }
+      // Close the ring so the stroke joins the last vertex back to the
+      // first — otherwise there's a visible gap on Danseiji outlines.
+      mutable.closeSubpath()
       path = mutable
     }
     


### PR DESCRIPTION
`GeoDrawer.draw(_ bounds:in:)` built the bezier outline path with `move`
+ a series of `addLine` calls but never called `closeSubpath()`, so the last vertex never connected back to the first when stroked. On Danseiji projections (whose edge polygon vertices are dense and asymmetric) this showed up as a visible gap at the polygon's start/end seam.

The SVG renderer already closes the path with `Z`, so it didn't have the bug — only the Core Graphics path did. Add a `closeSubpath()` to match.